### PR TITLE
Support setters in UiBinder.

### DIFF
--- a/user/src/com/google/gwt/uibinder/rebind/AbstractFieldWriter.java
+++ b/user/src/com/google/gwt/uibinder/rebind/AbstractFieldWriter.java
@@ -337,7 +337,12 @@ abstract class AbstractFieldWriter implements FieldWriter {
 
     if ((ownerField != null) && !ownerField.isProvided()) {
       w.newline();
-      w.write("owner.%1$s = %1$s;", name);
+
+      if (ownerField.getSetterMethod() != null) {
+        w.write("owner.%1$s(%2$s);", ownerField.getSetterMethod().getName(), name);
+      } else {
+        w.write("owner.%1$s = %2$s;", name, name);
+      }
     }
 
     w.newline();

--- a/user/src/com/google/gwt/uibinder/rebind/AbstractFieldWriter.java
+++ b/user/src/com/google/gwt/uibinder/rebind/AbstractFieldWriter.java
@@ -216,7 +216,11 @@ abstract class AbstractFieldWriter implements FieldWriter {
     // Check initializer.
     if (initializer == null) {
       if (ownerField != null && ownerField.isProvided()) {
-        initializer = String.format("owner.%s", name);
+        if (ownerField.getGetterMethod() != null) {
+          initializer = String.format("owner.%s()", ownerField.getGetterMethod().getName());
+        } else {
+          initializer = String.format("owner.%s", name);
+        }
       } else {
         JClassType type = getInstantiableType();
         if (type != null) {

--- a/user/src/com/google/gwt/uibinder/rebind/UiBinderWriter.java
+++ b/user/src/com/google/gwt/uibinder/rebind/UiBinderWriter.java
@@ -1319,7 +1319,12 @@ public class UiBinderWriter implements Statements {
       /*
        * And initialize the field
        */
-      niceWriter.write("owner.%1$s = %2$s;", ownerField.getName(), templateField);
+
+      if (ownerField.getSetterMethod() != null) {
+        niceWriter.write("owner.%1$s(%2$s);", ownerField.getSetterMethod().getName(), templateField);
+      } else {
+        niceWriter.write("owner.%1$s = %2$s;", ownerField.getName(), templateField);
+      }
     } else {
       /*
        * But with @UiField(provided=true) the user builds it, so reverse the

--- a/user/src/com/google/gwt/uibinder/rebind/model/OwnerClass.java
+++ b/user/src/com/google/gwt/uibinder/rebind/model/OwnerClass.java
@@ -169,7 +169,7 @@ public class OwnerClass {
           logger.die("Factory return type is not a class in method "
               + method.getName());
         }
-        
+
         JParameterizedType paramType = factoryType.isParameterized();
         if (paramType != null) {
           factoryType = paramType.getRawType();
@@ -240,6 +240,27 @@ public class OwnerClass {
   }
 
   /**
+   * Scans the owner class to find all methods annotated with @UiHandler, and
+   * adds them to their respective fields.
+   *
+   * @param ownerType the type of the owner class
+   */
+  private void findUiHandlers(JClassType ownerType) {
+    JMethod[] methods = ownerType.getMethods();
+    for (JMethod method : methods) {
+      if (method.isAnnotationPresent(UiHandler.class)) {
+        uiHandlers.add(method);
+      }
+    }
+
+    // Recurse to superclass
+    JClassType superclass = ownerType.getSuperclass();
+    if (superclass != null) {
+      findUiHandlers(superclass);
+    }
+  }
+
+  /**
    * Returns true iff method is a single parameter method that takes a {@param type}, returns
    * nothing, and its name contains the {@param fieldName}.
    */
@@ -262,26 +283,5 @@ public class OwnerClass {
     }
 
     return type.isAssignableTo((JClassType) params[0]);
-  }
-
-  /**
-   * Scans the owner class to find all methods annotated with @UiHandler, and
-   * adds them to their respective fields.
-   *
-   * @param ownerType the type of the owner class
-   */
-  private void findUiHandlers(JClassType ownerType) {
-    JMethod[] methods = ownerType.getMethods();
-    for (JMethod method : methods) {
-      if (method.isAnnotationPresent(UiHandler.class)) {
-        uiHandlers.add(method);
-      }
-    }
-
-    // Recurse to superclass
-    JClassType superclass = ownerType.getSuperclass();
-    if (superclass != null) {
-      findUiHandlers(superclass);
-    }
   }
 }

--- a/user/src/com/google/gwt/uibinder/rebind/model/OwnerClass.java
+++ b/user/src/com/google/gwt/uibinder/rebind/model/OwnerClass.java
@@ -213,6 +213,7 @@ public class OwnerClass {
         }
 
         JMethod setterMethod = null;
+        JMethod getterMethod = null;
         for (JMethod method : methods) {
           if (isSetterMethodForField(method, ownerFieldType, field.getName())) {
             if (setterMethod != null) {
@@ -222,9 +223,14 @@ public class OwnerClass {
 
             setterMethod = method;
           }
+          if (isGetterMethodForField(method, ownerFieldType, field.getName())) {
+            if (getterMethod == null || method.getName().length() < getterMethod.getName().length()) {
+              getterMethod = method;
+            }
+          }
         }
 
-        OwnerField ownerField = new OwnerField(field, logger, context, setterMethod);
+        OwnerField ownerField = new OwnerField(field, logger, context, setterMethod, getterMethod);
         String ownerFieldName = field.getName();
 
         uiFields.put(ownerFieldName, ownerField);
@@ -258,6 +264,22 @@ public class OwnerClass {
     if (superclass != null) {
       findUiHandlers(superclass);
     }
+  }
+
+  /**
+   * Returns true iff method is a no parameter method that returns a {@param type}
+   * and its name contains the {@param fieldName}.
+   */
+  private boolean isGetterMethodForField(JMethod method, JClassType type, String fieldName) {
+    if (!method.getName().toUpperCase().contains(fieldName.toUpperCase())) {
+        return false;
+    }
+
+    if (method.getReturnType() != type) {
+        return false;
+    }
+
+    return method.getParameterTypes().length == 0;
   }
 
   /**

--- a/user/src/com/google/gwt/uibinder/rebind/model/OwnerField.java
+++ b/user/src/com/google/gwt/uibinder/rebind/model/OwnerField.java
@@ -18,7 +18,9 @@ package com.google.gwt.uibinder.rebind.model;
 import com.google.gwt.core.ext.UnableToCompleteException;
 import com.google.gwt.core.ext.typeinfo.JClassType;
 import com.google.gwt.core.ext.typeinfo.JField;
+import com.google.gwt.core.ext.typeinfo.JMethod;
 import com.google.gwt.uibinder.client.UiField;
+import com.google.gwt.uibinder.rebind.IndentedWriter;
 import com.google.gwt.uibinder.rebind.MortalLogger;
 import com.google.gwt.uibinder.rebind.UiBinderContext;
 
@@ -35,6 +37,7 @@ public class OwnerField {
   private final String name;
   private final OwnerFieldClass fieldType;
   private final boolean isProvided;
+  private final JMethod setterMethod;
 
   /**
    * Constructor.
@@ -44,8 +47,22 @@ public class OwnerField {
    * @param context 
    */
   public OwnerField(JField field, MortalLogger logger, UiBinderContext context)
+            throws UnableToCompleteException {
+      this(field, logger, context, null);
+  }
+
+  /**
+   * Constructor.
+   *
+   * @param field the field of the owner class
+   * @param logger
+   * @param context 
+   * @param setterMethod
+   */
+  public OwnerField(JField field, MortalLogger logger, UiBinderContext context, JMethod setterMethod)
       throws UnableToCompleteException {
     this.name = field.getName();
+    this.setterMethod = setterMethod;
 
     // Get the field type and ensure it's a class or interface
     JClassType fieldClassType = field.getType().isClassOrInterface();
@@ -96,6 +113,14 @@ public class OwnerField {
    */
   public boolean isProvided() {
     return isProvided;
+  }
+
+  /**
+   * Returns the setter method used to set this field if one exists.
+   * If null then set the field regularly.
+   */
+  public JMethod getSetterMethod() {
+    return setterMethod;
   }
 
   @Override

--- a/user/src/com/google/gwt/uibinder/rebind/model/OwnerField.java
+++ b/user/src/com/google/gwt/uibinder/rebind/model/OwnerField.java
@@ -37,6 +37,7 @@ public class OwnerField {
   private final OwnerFieldClass fieldType;
   private final boolean isProvided;
   private final JMethod setterMethod;
+  private final JMethod getterMethod;
 
   /**
    * Constructor.
@@ -47,7 +48,7 @@ public class OwnerField {
    */
   public OwnerField(JField field, MortalLogger logger, UiBinderContext context)
             throws UnableToCompleteException {
-      this(field, logger, context, null);
+      this(field, logger, context, null, null);
   }
 
   /**
@@ -57,11 +58,13 @@ public class OwnerField {
    * @param logger
    * @param context
    * @param setterMethod
+   * @param getterMethod
    */
-  public OwnerField(JField field, MortalLogger logger, UiBinderContext context, JMethod setterMethod)
+  public OwnerField(JField field, MortalLogger logger, UiBinderContext context, JMethod setterMethod, JMethod getterMethod)
       throws UnableToCompleteException {
     this.name = field.getName();
     this.setterMethod = setterMethod;
+    this.getterMethod = getterMethod;
 
     // Get the field type and ensure it's a class or interface
     JClassType fieldClassType = field.getType().isClassOrInterface();
@@ -97,6 +100,14 @@ public class OwnerField {
   public JClassType getRawType() {
     // This shorten getType().getRawType() and make tests easier.
     return getType().getRawType();
+  }
+
+  /**
+   * Returns the getter method used to get this field if one exists.
+   * If null then get the field reguarly.
+   */
+  public JMethod getGetterMethod() {
+    return getterMethod;
   }
 
   /**

--- a/user/src/com/google/gwt/uibinder/rebind/model/OwnerField.java
+++ b/user/src/com/google/gwt/uibinder/rebind/model/OwnerField.java
@@ -20,7 +20,6 @@ import com.google.gwt.core.ext.typeinfo.JClassType;
 import com.google.gwt.core.ext.typeinfo.JField;
 import com.google.gwt.core.ext.typeinfo.JMethod;
 import com.google.gwt.uibinder.client.UiField;
-import com.google.gwt.uibinder.rebind.IndentedWriter;
 import com.google.gwt.uibinder.rebind.MortalLogger;
 import com.google.gwt.uibinder.rebind.UiBinderContext;
 
@@ -44,7 +43,7 @@ public class OwnerField {
    *
    * @param field the field of the owner class
    * @param logger
-   * @param context 
+   * @param context
    */
   public OwnerField(JField field, MortalLogger logger, UiBinderContext context)
             throws UnableToCompleteException {
@@ -56,7 +55,7 @@ public class OwnerField {
    *
    * @param field the field of the owner class
    * @param logger
-   * @param context 
+   * @param context
    * @param setterMethod
    */
   public OwnerField(JField field, MortalLogger logger, UiBinderContext context, JMethod setterMethod)
@@ -101,6 +100,14 @@ public class OwnerField {
   }
 
   /**
+   * Returns the setter method used to set this field if one exists.
+   * If null then set the field regularly.
+   */
+  public JMethod getSetterMethod() {
+    return setterMethod;
+  }
+
+  /**
    * Returns a descriptor for the type of the field.
    */
   public OwnerFieldClass getType() {
@@ -113,14 +120,6 @@ public class OwnerField {
    */
   public boolean isProvided() {
     return isProvided;
-  }
-
-  /**
-   * Returns the setter method used to set this field if one exists.
-   * If null then set the field regularly.
-   */
-  public JMethod getSetterMethod() {
-    return setterMethod;
   }
 
   @Override

--- a/user/test/com/google/gwt/uibinder/rebind/model/OwnerClassTest.java
+++ b/user/test/com/google/gwt/uibinder/rebind/model/OwnerClassTest.java
@@ -269,6 +269,40 @@ public class OwnerClassTest extends TestCase {
             code.append("}\n");
             return code;
           }
+        },
+        new MockJavaResource(
+            "com.google.gwt.uibinder.rebind.model.SetterMethodClass") {
+          @Override
+          public CharSequence getContent() {
+            StringBuffer code = new StringBuffer();
+            code.append("package com.google.gwt.uibinder.rebind.model;\n");
+            code.append("import com.google.gwt.uibinder.client.UiField;\n");
+            code.append("import com.google.gwt.user.client.ui.Label;\n");
+            code.append("public class ParentUiBinderClass {");
+            code.append("  @UiField private Label label1;");
+            code.append("  public void setLabel1(Label l1) {");
+            code.append("    label1 = l1;");
+            code.append("  }");
+            code.append("}\n");
+            return code;
+          }
+        },
+        new MockJavaResource(
+            "com.google.gwt.uibinder.rebind.model.ScalaSetterMethodClass") {
+          @Override
+          public CharSequence getContent() {
+            StringBuffer code = new StringBuffer();
+            code.append("package com.google.gwt.uibinder.rebind.model;\n");
+            code.append("import com.google.gwt.uibinder.client.UiField;\n");
+            code.append("import com.google.gwt.user.client.ui.Label;\n");
+            code.append("public class ParentUiBinderClass {");
+            code.append("  @UiField private Label label1;");
+            code.append("  public void label1_$eq(Label l1) {");
+            code.append("    label1 = l1;");
+            code.append("  }");
+            code.append("}\n");
+            return code;
+          }
         },};
 
     Set<Resource> rtn = new HashSet<Resource>(UiJavaResources.getUiResources());
@@ -526,5 +560,33 @@ public class OwnerClassTest extends TestCase {
     String[] mouseOverFields = mouseOverAnnotation.value();
     assertEquals(1, mouseOverFields.length);
     assertEquals("label1", mouseOverFields[0]);
+  }
+    
+  public void testOwnerClass_setterMethod() throws UnableToCompleteException {
+    // Finds traditional setter.
+    JClassType ownerType = types.findType("com.google.gwt.uibinder.rebind.model.SetterMethodClass");
+    OwnerClass ownerClass = new OwnerClass(ownerType, MortalLogger.NULL,
+        uiBinderCtx);
+
+    OwnerField ownerField = ownerClass.getUiField("label1");
+    assertNotNull(ownerField);
+    assertEquals("label1", ownerField.getName());
+    JMethod setter = ownerField.getSetterMethod();
+    assertNotNull(setter);
+    assertEquals("setLabel1", setter.getName());
+  }
+    
+  public void testOwnerClass_scalaSetterMethod() throws UnableToCompleteException {
+    // Finds scala named setter.
+    JClassType ownerType = types.findType("com.google.gwt.uibinder.rebind.model.ScalaSetterMethodClass");
+    OwnerClass ownerClass = new OwnerClass(ownerType, MortalLogger.NULL,
+        uiBinderCtx);
+
+    OwnerField ownerField = ownerClass.getUiField("label1");
+    assertNotNull(ownerField);
+    assertEquals("label1", ownerField.getName());
+    JMethod setter = ownerField.getSetterMethod();
+    assertNotNull(setter);
+    assertEquals("label1_$eq", setter.getName());
   }
 }


### PR DESCRIPTION
This is to support UiBinder in scala by using scala's auto generated setters.

A 'setter' is loosely defined as follows:
1) It takes 1 parameter of field type.
2) It's name contains the field name (case insensitive).
3) It has return type void.

It's clearly not fool proof. I didn't think it made sense to hardcode the expected format for scala.

If this is too loose we could go to supporting only the 'set${fieldName}' format and require scala's annotation of @BeanProperty in addition to @UiField.
