### PR TITLE
More thoroughly avoid caching of Jribble units.

### DIFF
--- a/dev/core/src/com/google/gwt/dev/javac/CompilationStateBuilder.java
+++ b/dev/core/src/com/google/gwt/dev/javac/CompilationStateBuilder.java
@@ -440,9 +440,14 @@ public class CompilationStateBuilder {
       }
 
       CompilationUnit cachedUnit = unitCache.find(resource.getPathPrefix() + resource.getPath());
+      
+      // Skip Jribble units. Their type dependencies are currently not recorded
+      // accurately, and anyway, it is not clear there is a speedup from loading
+      // from cache rather than loading from bytecode.
+      if (builder.isJribble()) {
+        cachedUnit = null;
+      }
 
-      // Try to rescue cached units from previous sessions where a jar has been
-      // recompiled.
       if (cachedUnit != null && cachedUnit.getLastModified() != resource.getLastModified()) {
         unitCache.remove(cachedUnit);
         if (cachedUnit instanceof CachedCompilationUnit


### PR DESCRIPTION
Addresses issue #31 (https://github.com/scalagwt/scalagwt-gwt/issues/31).

After making this change, I observed refreshing in a browser to cause new .jribble files to be picked up, without having to restart development mode.
