### PR TITLE
Fix handling of empty array literals.

### DIFF
--- a/dev/core/src/com/google/gwt/dev/jjs/impl/jribble/JribbleAstBuilder.java
+++ b/dev/core/src/com/google/gwt/dev/jjs/impl/jribble/JribbleAstBuilder.java
@@ -121,6 +121,7 @@ import com.google.gwt.dev.jjs.impl.jribble.JribbleProtos.While;
 import com.google.gwt.dev.util.StringInterner;
 
 import java.util.ArrayList;
+import java.util.Collections;
 import java.util.HashMap;
 import java.util.LinkedList;
 import java.util.List;
@@ -584,6 +585,8 @@ public class JribbleAstBuilder {
     }
 
     private JNewArray newArray(NewArray expr, LocalStack local) {
+      //semantics of NewArray is tricky, check jribble.proto file
+      //for examples
       JType type = mapper.getType(expr.getElementType()); // this is the element
                                                           // type
       assert (expr.getInitExprCount() > 0 && expr.getDimensions() == 1)
@@ -595,6 +598,9 @@ public class JribbleAstBuilder {
           initializers.add(expression(e, local));
         }
         return JNewArray.createInitializers(UNKNOWN, arrayType, initializers);
+      } else if (expr.getDimensions() == 1 && expr.getDimensionExprCount() == 0) {
+        JArrayType arrayType = new JArrayType(type);
+        return JNewArray.createInitializers(UNKNOWN, arrayType, Collections.<JExpression> emptyList());
       } else {
         for (int i = 0; i < expr.getDimensions(); i++) {
           type = new JArrayType(type);

--- a/dev/core/src/com/google/gwt/dev/jjs/impl/jribble/jribble.proto
+++ b/dev/core/src/com/google/gwt/dev/jjs/impl/jribble/jribble.proto
@@ -275,6 +275,31 @@ message MethodSignature {
   required Type returnType = 4;
 }
 
+/* Encodes both new array expresions and array literals.
+ * Below there are Java expressions and corresponding
+ * protobufs that encode them.
+ *
+ * new Object[7]
+ * newArray {
+ *   elementType ... //encoding for java.lang.Object
+ *   dimensions: 1
+ *   dimensionExpr { ... //expr encoding 7 }
+ * }
+ *
+ * {} //in context where Object[] is expected
+ * newArray {
+ *   elementType ... //encoding for java.lang.Object
+ *   dimensions: 1
+ * }
+ *
+ * { ex1, ex2 } //in context where Object[] is expected
+ * newArray {
+ *   elementType ... //encoding for java.lang.Object
+ *   dimensions: 1
+ *   initExpr { //encoding for ex1 }
+ *   initExpr { //encoding for ex2 }
+ * }
+ */
 message NewArray {
   required Type elementType = 1;
   required int32 dimensions = 2;


### PR DESCRIPTION
Empty array literals are handled in a tricky
way and can be easily confused with
expression `new Object[]` which is illegal
in Java.

We need a special handling of this case that
this commit introduces.

Also, added documentation that explains how
different cases are encoded so others should
have easier time following logic processing
NewArray messages.

Fixes #33.
