### PR TITLE
add initial support for jsni in scala

### DIFF
--- a/dev/core/src/com/google/gwt/dev/javac/JribbleCompilationUnit.java
+++ b/dev/core/src/com/google/gwt/dev/javac/JribbleCompilationUnit.java
@@ -43,6 +43,7 @@ public class JribbleCompilationUnit extends CompilationUnit {
   private JDeclaredType declaredType;
   private Dependencies dependencies;
   private MethodArgNamesLookup methodArgNamesLookup;
+  private List<JsniMethod> jsniMethods;
   private final Resource resource;
 
   public JribbleCompilationUnit(Resource resource, CompiledClass compiledClass) {
@@ -71,7 +72,10 @@ public class JribbleCompilationUnit extends CompilationUnit {
 
   @Override
   public List<JsniMethod> getJsniMethods() {
-    return Collections.emptyList();
+    if (jsniMethods == null) {
+      loadFromJribble();
+    }
+    return jsniMethods;
   }
 
   @Override
@@ -177,6 +181,7 @@ public class JribbleCompilationUnit extends CompilationUnit {
       dependencies =
           Dependencies.buildFromApiRefs(packageName, new ArrayList<String>(result.apiRefs));
       methodArgNamesLookup = result.methodArgNames;
+      jsniMethods = result.jsniMethods;
       declaredType = result.types.get(0);
     } catch (IOException ex) {
       throw new RuntimeException("Unexpected error while deserializing a Jribble file", ex);

--- a/dev/core/test/com/google/gwt/dev/jjs/impl/jribble/JribbleAstBuilderTest.testNativeMethod.ast
+++ b/dev/core/test/com/google/gwt/dev/jjs/impl/jribble/JribbleAstBuilderTest.testNativeMethod.ast
@@ -1,0 +1,26 @@
+class Bar extends Object {
+  private static final void $clinit(){
+    Object.$clinit();
+  }
+
+  private final void $init(){
+  }
+
+  public Class getClass(){
+    return Bar.class;
+  }
+
+  public native String zaz() /*-{
+    return 'jsni';
+  }-*/;
+
+  public native int add(int x, int y) /*-{
+    return x + y;
+  }-*/;
+
+  public Bar(){
+    this.$init();
+    super();
+  }
+
+}


### PR DESCRIPTION
squashed version of https://github.com/scalagwt/scalagwt-gwt/pull/39

There are a few things still missing compared to java jsni support.  First and foremost, it is currently possible to call into native javascript functions from scala, but not to call back out to scala from inside javascript, nor to reference scala fields.  In addition, this commit does not include warnings about unsafe native long handling, so the parameters passed in and out of native methods should be limited to types that have native representation, e.g. int, string, and subclasses of JavaScriptObject.
